### PR TITLE
Clean column names, separate link from questions

### DIFF
--- a/This is Jeopardy.ipynb
+++ b/This is Jeopardy.ipynb
@@ -75,12 +75,52 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 173,
    "metadata": {},
    "outputs": [],
    "source": [
     "import pandas as pd\n",
-    "pd.set_option('display.max_colwidth', None)"
+    "import re\n",
+    "from bs4 import BeautifulSoup, Tag, NavigableString\n",
+    "pd.set_option('display.max_colwidth', None)\n",
+    "jeopardy = pd.read_csv(\"jeopardy.csv\")\n",
+    "#rename the columns\n",
+    "jeopardy = jeopardy.rename(columns = {'Show Number':'show_number', ' Air Date':'air_date', ' Round':'round', ' Category':'category', ' Value': 'value',\n",
+    "       ' Question':'question', ' Answer':'answer'})\n",
+    "#create a link column from the links in text string in a pandas column\n",
+    "def link_finder (column):\n",
+    "       soup = BeautifulSoup(column, 'html.parser')\n",
+    "       link = soup.find('a')\n",
+    "       if link != None:\n",
+    "              url = link['href']\n",
+    "       else:\n",
+    "              url = None\n",
+    "       return url\n",
+    "#take a link out of a text string in a pandas column     \n",
+    "def link_remover (column):\n",
+    "       column_txt = str(column)\n",
+    "       soup = BeautifulSoup(column, 'html.parser')\n",
+    "       link = soup.find('a')\n",
+    "       if link != None:\n",
+    "              url = link['href']\n",
+    "              link_text = link.text\n",
+    "              #update the column_txt to remove the href\n",
+    "              column_update = column_txt.replace(str(link), str(link.text))\n",
+    "              column_linkless = (column_update)\n",
+    "              #create a new column with the URL\n",
+    "       else:\n",
+    "              column_linkless = (column_txt)\n",
+    "       return column_linkless\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 174,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "jeopardy['link'] = jeopardy.question.apply(link_finder)\n",
+    "jeopardy['question'] = jeopardy.question.apply(link_remover)"
    ]
   },
   {
@@ -198,7 +238,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -212,7 +252,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.11"
+   "version": "3.10.6"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "916dbcbb3f70747c44a77c7bcd40155683ae19c65e1c03b4aa3499c5328201f1"
+   }
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
I removed spaces and capitals from the dataframe column names and updated the "questions' column to not include links, but to keep the link text from the html href, using BeautifulSoup.  I also added a 'links' column so that the link type (jpg, mp3, or video) could be analyzed. 